### PR TITLE
Basic automation setup for Expo app

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -49,16 +49,15 @@ steps:
         timeout_in_minutes: 10
         plugins:
           docker-compose#v5.12.1:
-            pull: maze-runner
             run: maze-runner
             use-aliases: true
             command:
               - "--farm=bb"
               - "--device==ANDROID_12|ANDROID_13|ANDROID_14|ANDROID_15"
-              - "--app={{build-android-app:bs-android-url.txt}}"
+              - "--app=/app/react-native-app/bb-android-url.txt"
           artifacts#v1.9.0:
             download:
-              - "bb-android-url.txt"
+              - "src/react-native-app/bb-android-url.txt"
             upload:
               - "maze_output/maze_output.zip"
         concurrency: 25
@@ -70,7 +69,6 @@ steps:
         timeout_in_minutes: 10
         plugins:
           docker-compose#v5.12.1:
-            pull: maze-runner
             run: maze-runner
             use-aliases: true
             command:
@@ -79,10 +77,9 @@ steps:
               - "--app=/app/react-native-app/bb-ios-url.txt"
           artifacts#v1.9.0:
             download:
-              - "src/react-native-app/bb-android-url.txt"
+              - "src/react-native-app/bb-ios-url.txt"
             upload:
               - "maze_output/maze_output.zip"
         concurrency: 25
         concurrency_group: "bitbar"
         concurrency_method: eager
-

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -15,7 +15,7 @@ steps:
           NODE_VERSION: "22"
           FRONTEND_PROXY_HOST: "placeholder"
           FRONTEND_PROXY_PORT: "8080"
-          BUGSNAG_API_KEY: "placeholder"
+          BUGSNAG_API_KEY: "12345678901234567890123456789012"
         plugins:
           artifacts#v1.9.4:
             upload:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -47,6 +47,8 @@ steps:
       - label: ":bitbar: Run Android app"
         depends_on: "build-android-app"
         timeout_in_minutes: 10
+        agents:
+          queue: "opensource"
         plugins:
           docker-compose#v5.12.1:
             run: maze-runner
@@ -54,7 +56,7 @@ steps:
             command:
               - "--farm=bb"
               - "--device==ANDROID_12|ANDROID_13|ANDROID_14|ANDROID_15"
-              - "--app=/app/react-native-app/bb-android-url.txt"
+              - "--app=@/app/react-native-app/bb-android-url.txt"
           artifacts#v1.9.0:
             download:
               - "src/react-native-app/bb-android-url.txt"
@@ -67,14 +69,16 @@ steps:
       - label: ":bitbar: Run iOS app"
         depends_on: "build-ios-app"
         timeout_in_minutes: 10
+        agents:
+          queue: "opensource"
         plugins:
           docker-compose#v5.12.1:
             run: maze-runner
             use-aliases: true
             command:
               - "--farm=bb"
-              - "--device==IOS_14|IOS_15|IOS_16|IOS_17"
-              - "--app=/app/react-native-app/bb-ios-url.txt"
+              - "--device=IOS_14|IOS_15|IOS_16|IOS_17"
+              - "--app=@/app/react-native-app/bb-ios-url.txt"
           artifacts#v1.9.0:
             download:
               - "src/react-native-app/bb-ios-url.txt"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -35,6 +35,9 @@ steps:
           JAVA_VERSION: "17"
           NODE_VERSION: "18"
           XCODE_VERSION: "15.4.0"
+          FRONTEND_PROXY_HOST: "placeholder"
+          FRONTEND_PROXY_PORT: "8080"
+          BUGSNAG_API_KEY: "12345678901234567890123456789012"
         plugins:
           artifacts#v1.9.4:
             upload:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,37 +2,87 @@ agents:
   queue: "macos-15"
 
 steps:
-  - group: ":hammer: Build Apps"
+  - group: "Build Apps"
     steps:
       - label: ":android: Build Android App"
-        key: "build_android_app"
+        key: "build-android-app"
         commands:
+          - "./src/react-native-app/scripts/set_build_vars.sh"
           - "./src/react-native-app/scripts/build.sh android"
-          - "bundle exec upload-app --farm=bs --app=src/react-native-app/android/app/build/outputs/apk/release/app-release.apk --app-id-file=bs-android-url.txt"
+          - "bundle exec upload-app --farm=bb --app=src/react-native-app/android/app/build/outputs/apk/release/app-release.apk --app-id-file=./src/react-native-app/bb-android-url.txt"
         env:
           JAVA_VERSION: "17"
           NODE_VERSION: "22"
+          FRONTEND_PROXY_HOST: "placeholder"
+          FRONTEND_PROXY_PORT: "8080"
+          BUGSNAG_API_KEY: "placeholder"
         plugins:
-          artifacts#v1.5.0:
+          artifacts#v1.9.4:
             upload:
               - "src/react-native-app/android/app/build/outputs/apk/release/app-release.apk"
-              - "bs-android-url.txt"
+              - "src/react-native-app/bb-android-url.txt"
         timeout_in_minutes: 20
 
       - label: ":ios: Build iOS App"
-        key: "build_ios_app"
+        key: "build-ios-app"
         agents:
           queue: "macos-14"
         commands:
+          - "./src/react-native-app/scripts/set_build_vars.sh"
           - "./src/react-native-app/scripts/build.sh ios"
-          - "bundle exec upload-app --farm=bs --app=src/react-native-app/ios/output/reactnativeapp.ipa --app-id-file=bs-ios-url.txt"
+          - "bundle exec upload-app --farm=bb --app=src/react-native-app/ios/output/reactnativeapp.ipa --app-id-file=./src/react-native-app/bb-ios-url.txt"
         env:
           JAVA_VERSION: "17"
           NODE_VERSION: "18"
           XCODE_VERSION: "15.4.0"
         plugins:
-          artifacts#v1.5.0:
+          artifacts#v1.9.4:
             upload:
               - "src/react-native-app/ios/output/reactnativeapp.ipa"
-              - "bs-ios-url.txt"
+              - "src/react-native-app/bb-ios-url.txt"
         timeout_in_minutes: 20
+
+  - group: "Run the app"
+    steps:
+      - label: ":bitbar: Run Android app"
+        depends_on: "build-android-app"
+        timeout_in_minutes: 10
+        plugins:
+          docker-compose#v5.12.1:
+            pull: maze-runner
+            run: maze-runner
+            use-aliases: true
+            command:
+              - "--farm=bb"
+              - "--device==ANDROID_12|ANDROID_13|ANDROID_14|ANDROID_15"
+              - "--app={{build-android-app:bs-android-url.txt}}"
+          artifacts#v1.9.0:
+            download:
+              - "bb-android-url.txt"
+            upload:
+              - "maze_output/maze_output.zip"
+        concurrency: 25
+        concurrency_group: "bitbar"
+        concurrency_method: eager
+
+      - label: ":bitbar: Run iOS app"
+        depends_on: "build-ios-app"
+        timeout_in_minutes: 10
+        plugins:
+          docker-compose#v5.12.1:
+            pull: maze-runner
+            run: maze-runner
+            use-aliases: true
+            command:
+              - "--farm=bb"
+              - "--device==IOS_14|IOS_15|IOS_16|IOS_17"
+              - "--app=/app/react-native-app/bb-ios-url.txt"
+          artifacts#v1.9.0:
+            download:
+              - "src/react-native-app/bb-android-url.txt"
+            upload:
+              - "maze_output/maze_output.zip"
+        concurrency: 25
+        concurrency_group: "bitbar"
+        concurrency_method: eager
+

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,7 @@ test/tracetesting/tracetesting-vars.yaml
 *.apk
 
 !src/currency/build
+
+maze_output/
+maze-runner.log
+Gemfile.lock

--- a/.licenserc.json
+++ b/.licenserc.json
@@ -57,7 +57,8 @@
         "src/recommendation/demo_pb2_grpc.py",
         "internal/tools/",
         ".buildkite/",
-        "src/react-native-app/scripts/"
+        "src/react-native-app/scripts/",
+        "features/"
     ]
   },
   {

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,9 @@
 source 'https://rubygems.org'
-gem 'bugsnag-maze-runner', '~>10.0'
+
+gem 'bugsnag-maze-runner', '~> 10.0'
+
+# Use a specific branch
+#gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', branch: 'main'
+
+# Locally, you can run against Maze Runner branches and uncommitted changes:
+#gem 'bugsnag-maze-runner', path: '../maze-runner'

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'bugsnag-maze-runner', '~> 10.0'
+gem 'openssl'
 
 # Use a specific branch
 #gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', branch: 'main'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -830,3 +830,34 @@ services:
       timeout: 10s
       retries: 10
     logging: *logging
+
+  # ******************
+  # Demo automation
+  # ******************
+  maze-runner:
+    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v10-cli
+    environment:
+      BITBAR_USERNAME:
+      BITBAR_ACCESS_KEY:
+      BUILDKITE:
+      BUILDKITE_BRANCH:
+      BUILDKITE_BUILD_CREATOR:
+      BUILDKITE_BUILD_NUMBER:
+      BUILDKITE_BUILD_URL:
+      BUILDKITE_JOB_ID:
+      BUILDKITE_LABEL:
+      BUILDKITE_MESSAGE:
+      BUILDKITE_PIPELINE_NAME:
+      BUILDKITE_PIPELINE_SLUG:
+      BUILDKITE_REPO:
+      BUILDKITE_RETRY_COUNT:
+      BUILDKITE_STEP_KEY:
+    networks:
+      default:
+        aliases:
+          - maze-runner
+    volumes:
+      - ./src/react-native-app:/app/react-native-app
+      - ./features/:/app/features
+      - ./maze_output:/app/maze_output
+      - /var/run/docker.sock:/var/run/docker.sock

--- a/features/basics.feature
+++ b/features/basics.feature
@@ -1,6 +1,0 @@
-Feature: Manual creation of spans
-
-  Scenario: Retry a manual span
-    Given I wait for 10 seconds
-    And I log the page source
-#    And I click the element named "startManualSpan"

--- a/features/basics.feature
+++ b/features/basics.feature
@@ -1,0 +1,6 @@
+Feature: Manual creation of spans
+
+  Scenario: Retry a manual span
+    Given I wait for 10 seconds
+    And I log the page source
+#    And I click the element named "startManualSpan"

--- a/features/optel-demo.feature
+++ b/features/optel-demo.feature
@@ -1,0 +1,5 @@
+Feature: Otel demo
+
+  Scenario: Placeholder only
+    Given I wait for 10 seconds
+    And I log the page source

--- a/features/steps/steps.rb
+++ b/features/steps/steps.rb
@@ -1,8 +1,3 @@
 When('I log the page source') do
   $logger.info Maze.driver.page_source
 end
-
-When("I click the element named {string}") do |element_name|
-  elements = Maze.driver.find_elements(:name, element_name)
-  $logger.info elements.inspect
-end

--- a/features/steps/steps.rb
+++ b/features/steps/steps.rb
@@ -1,0 +1,8 @@
+When('I log the page source') do
+  $logger.info Maze.driver.page_source
+end
+
+When("I click the element named {string}") do |element_name|
+  elements = Maze.driver.find_elements(:name, element_name)
+  $logger.info elements.inspect
+end

--- a/src/react-native-app/.env
+++ b/src/react-native-app/.env
@@ -1,5 +1,6 @@
 # https://docs.expo.dev/guides/environment-variables/
-
+# 10.0.2.2 for Android emulator to access host machine
+EXPO_PUBLIC_FRONTEND_PROXY_HOST=localhost
 EXPO_PUBLIC_FRONTEND_PROXY_PORT=8080
 EXPO_PUBLIC_BUGSNAG_API_KEY=your-api-key
 EXPO_PUBLIC_BUGSNAG_APP_VERSION=1.0.0

--- a/src/react-native-app/.env
+++ b/src/react-native-app/.env
@@ -1,5 +1,8 @@
 # https://docs.expo.dev/guides/environment-variables/
-# 10.0.2.2 for Android emulator to access host machine
+# Useful addresses:
+#   10.0.2.2 for Android emulators to access the host machine
+#   bs-local.com for the BrowserStack secure tunnel
+#   local for use with the BitBar secure tunnel
 EXPO_PUBLIC_FRONTEND_PROXY_HOST=localhost
 EXPO_PUBLIC_FRONTEND_PROXY_PORT=8080
 EXPO_PUBLIC_BUGSNAG_API_KEY=your-api-key

--- a/src/react-native-app/app.json
+++ b/src/react-native-app/app.json
@@ -14,7 +14,17 @@
     },
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "io.opentelemetry.reactnativeapp"
+      "bundleIdentifier": "io.opentelemetry.reactnativeapp",
+      "buildNumber": "1",
+      "infoPlist": {
+        "NSAppTransportSecurity": {
+          "NSExceptionDomains": {
+            "bs-local.com": {
+              "NSExceptionAllowsInsecureHTTPLoads": true
+            }
+          }
+        }
+      }
     },
     "android": {
       "adaptiveIcon": {

--- a/src/react-native-app/app/(tabs)/index.tsx
+++ b/src/react-native-app/app/(tabs)/index.tsx
@@ -20,7 +20,7 @@ BugsnagPerformance.start({
   apiKey: apiKey,
   appVersion: process.env.EXPO_PUBLIC_BUGSNAG_APP_VERSION,
   releaseStage: process.env.EXPO_PUBLIC_BUGSNAG_RELEASE_STAGE,
-  autoInstrumentAppStarts: false,
+  autoInstrumentAppStarts: true,
   tracePropagationUrls: [/^(http(s)?(:\/\/))?(www\.)?([0-9A-Za-z-\\.@:%_\+~#=]+)(\.[a-zA-Z]{2,3})?(\/.*)?$/],
 });
 

--- a/src/react-native-app/components/ProductCard/ProductCard.tsx
+++ b/src/react-native-app/components/ProductCard/ProductCard.tsx
@@ -16,7 +16,9 @@ interface IProps {
 }
 
 async function getImageURL(picture: string) {
-  return `http://${process.env.EXPO_PUBLIC_FRONTEND_PROXY_HOST}:${process.env.EXPO_PUBLIC_FRONTEND_PROXY_PORT}/images/products/${picture}`;
+  let imageUrl = `http://${process.env.EXPO_PUBLIC_FRONTEND_PROXY_HOST}:${process.env.EXPO_PUBLIC_FRONTEND_PROXY_PORT}/images/products/${picture}`;
+  console.error(`Using image URL: ${imageUrl}`);
+  return imageUrl;
 }
 
 const ProductCard = ({

--- a/src/react-native-app/components/ProductCard/ProductCard.tsx
+++ b/src/react-native-app/components/ProductCard/ProductCard.tsx
@@ -6,7 +6,6 @@
 import { Product } from "@/protos/demo";
 import { ThemedView } from "@/components/ThemedView";
 import { useState, useEffect, useMemo } from "react";
-import getLocalhost from "@/utils/Localhost";
 import { Image, Pressable, StyleSheet } from "react-native";
 import { ThemedText } from "@/components/ThemedText";
 import { useThemeColor } from "@/hooks/useThemeColor";
@@ -17,8 +16,7 @@ interface IProps {
 }
 
 async function getImageURL(picture: string) {
-  const localhost = await getLocalhost();
-  return `http://${localhost}:${process.env.EXPO_PUBLIC_FRONTEND_PROXY_PORT}/images/products/${picture}`;
+  return `http://${process.env.EXPO_PUBLIC_FRONTEND_PROXY_HOST}:${process.env.EXPO_PUBLIC_FRONTEND_PROXY_PORT}/images/products/${picture}`;
 }
 
 const ProductCard = ({

--- a/src/react-native-app/ios/reactnativeapp.xcodeproj/project.pbxproj
+++ b/src/react-native-app/ios/reactnativeapp.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -29,7 +29,7 @@
 		58EEBF8E8E6FB1BC6CAF49B5 /* libPods-reactnativeapp.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-reactnativeapp.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6C2E3173556A471DD304B334 /* Pods-reactnativeapp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-reactnativeapp.debug.xcconfig"; path = "Target Support Files/Pods-reactnativeapp/Pods-reactnativeapp.debug.xcconfig"; sourceTree = "<group>"; };
 		7A4D352CD337FB3A3BF06240 /* Pods-reactnativeapp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-reactnativeapp.release.xcconfig"; path = "Target Support Files/Pods-reactnativeapp/Pods-reactnativeapp.release.xcconfig"; sourceTree = "<group>"; };
-		7CA499B7C37DC82E3E64F2AB /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; name = PrivacyInfo.xcprivacy; path = reactnativeapp/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		7CA499B7C37DC82E3E64F2AB /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xml; name = PrivacyInfo.xcprivacy; path = reactnativeapp/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		92B0478F52474B4C808FD8B5 /* noop-file.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = "noop-file.swift"; path = "reactnativeapp/noop-file.swift"; sourceTree = "<group>"; };
 		AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = reactnativeapp/SplashScreen.storyboard; sourceTree = "<group>"; };
 		BB2F792C24A3F905000567C9 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
@@ -343,6 +343,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = reactnativeapp/reactnativeapp.entitlements;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 7W9PZ27Y5F;
 				ENABLE_BITCODE = NO;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
@@ -350,7 +351,10 @@
 				);
 				INFOPLIST_FILE = reactnativeapp/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
 				MARKETING_VERSION = 1.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
@@ -376,9 +380,13 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = reactnativeapp/reactnativeapp.entitlements;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 7W9PZ27Y5F;
 				INFOPLIST_FILE = reactnativeapp/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
 				MARKETING_VERSION = 1.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
@@ -447,14 +455,14 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
 				LD = "";
 				LDPLUSPLUS = "";
-				LD_RUNPATH_SEARCH_PATHS = "/usr/lib/swift $(inherited)";
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
 				LIBRARY_SEARCH_PATHS = "$(SDKROOT)/usr/lib/swift\"$(inherited)\"";
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					" ",
-				);
+				OTHER_LDFLAGS = "$(inherited)  ";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				USE_HERMES = true;
@@ -506,13 +514,13 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
 				LD = "";
 				LDPLUSPLUS = "";
-				LD_RUNPATH_SEARCH_PATHS = "/usr/lib/swift $(inherited)";
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
 				LIBRARY_SEARCH_PATHS = "$(SDKROOT)/usr/lib/swift\"$(inherited)\"";
 				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					" ",
-				);
+				OTHER_LDFLAGS = "$(inherited)  ";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				USE_HERMES = true;

--- a/src/react-native-app/ios/reactnativeapp/Info.plist
+++ b/src/react-native-app/ios/reactnativeapp/Info.plist
@@ -38,8 +38,25 @@
     <true/>
     <key>NSAppTransportSecurity</key>
     <dict>
+      <key>NSExceptionDomains</key>
+      <dict>
+        <key>bs-local.com</key>
+        <dict>
+          <key>NSExceptionAllowsInsecureHTTPLoads</key>
+          <true/>
+          <key>NSIncludesSubdomains</key>
+          <true/>
+        </dict>
+        <key>local</key>
+        <dict>
+          <key>NSExceptionAllowsInsecureHTTPLoads</key>
+          <true/>
+          <key>NSIncludesSubdomains</key>
+          <true/>
+        </dict>
+      </dict>
       <key>NSAllowsArbitraryLoads</key>
-      <false/>
+      <true/>
       <key>NSAllowsLocalNetworking</key>
       <true/>
     </dict>

--- a/src/react-native-app/scripts/set_build_vars.sh
+++ b/src/react-native-app/scripts/set_build_vars.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+sed_in_place() {
+    local script="$1"
+    local file="$2"
+
+    if [[ "$OSTYPE" == linux* ]]; then
+        sed -i "$script" "$file"
+    else
+        sed -i '' "$script" "$file"
+    fi
+}
+
+# Resolve directory of the script, regardless of where it's called from
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Go to the src/react-native-app directory (script is inside scripts/)
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+pushd "$ROOT_DIR"
+
+echo "Running from: $ROOT_DIR"
+
+sed_in_place "s/EXPO_PUBLIC_FRONTEND_PROXY_HOST=.*/EXPO_PUBLIC_FRONTEND_PROXY_HOST=${FRONTEND_PROXY_HOST}/" ".env"
+sed_in_place "s/EXPO_PUBLIC_FRONTEND_PROXY_PORT=.*/EXPO_PUBLIC_FRONTEND_PROXY_PORT=${FRONTEND_PROXY_PORT}/" ".env"
+sed_in_place "s/EXPO_PUBLIC_BUGSNAG_API_KEY=.*/EXPO_PUBLIC_BUGSNAG_API_KEY=${BUGSNAG_API_KEY}/" ".env"
+
+popd

--- a/src/react-native-app/utils/Request.ts
+++ b/src/react-native-app/utils/Request.ts
@@ -22,8 +22,7 @@ const request = async <T>({
     "content-type": "application/json",
   },
 }: IRequestParams): Promise<T> => {
-  const localhost = await getLocalhost();
-  const API_URL = `http://${localhost}:${process.env.EXPO_PUBLIC_FRONTEND_PROXY_PORT}`;
+  const API_URL = `http://${process.env.EXPO_PUBLIC_FRONTEND_PROXY_HOST}:${process.env.EXPO_PUBLIC_FRONTEND_PROXY_PORT}`;
   const requestURL = `${API_URL}${url}?${new URLSearchParams(queryParams).toString()}`;
   const requestBody = body ? JSON.stringify(body) : undefined;
   const response = await fetch(requestURL, {

--- a/src/react-native-app/utils/Request.ts
+++ b/src/react-native-app/utils/Request.ts
@@ -24,6 +24,7 @@ const request = async <T>({
 }: IRequestParams): Promise<T> => {
   const API_URL = `http://${process.env.EXPO_PUBLIC_FRONTEND_PROXY_HOST}:${process.env.EXPO_PUBLIC_FRONTEND_PROXY_PORT}`;
   const requestURL = `${API_URL}${url}?${new URLSearchParams(queryParams).toString()}`;
+  console.error(`Making request from: ${requestURL}`);
   const requestBody = body ? JSON.stringify(body) : undefined;
   const response = await fetch(requestURL, {
     method,


### PR DESCRIPTION
## Goal 

Adds a basic Maze Runner setup for the Expo app, running a placeholder scenario with the iOS and Android apps on BitBar.

## Design 

This change lays the tracks for using Maze Runner to automate the sending of spans from the React Native app into the Bugsnag Otel demo environment.  The iOS and Android apps already being built are used to create Appium sessions on BitBar and a placeholder scenario is run. 

For now the app doesn't work as it can't access the front end proxy service running in the cluster, but once it's opened up I've put enough in place for us to add the IP into the agents' secrets file.  

## Changeset

I've also made a few changes so that the iOS app builds locally in Xcode 26.

## Testing 

Covered by CI.